### PR TITLE
Refactor `numberOfCalendarDaysBetweenDates`

### DIFF
--- a/MegaController/RelativeTimeDateFormatter.swift
+++ b/MegaController/RelativeTimeDateFormatter.swift
@@ -15,13 +15,21 @@ struct RelativeTimeDateFormatter {
         self.calendar = calendar
     }
     
-    func stringForDate(date: NSDate, relativeToDate baseDate: NSDate) -> String {
-        var beginningOfDate: NSDate? = nil
-        var beginningOfBaseDate: NSDate? = nil
+    func getNumberOfCalendarDaysBetweenDates(startDate: NSDate, _ endDate: NSDate) ->  Int {
+        var beginningOfStartDate: NSDate? = nil
+        var beginningOfEndDate: NSDate? = nil
         
-        calendar.rangeOfUnit(.Day, startDate: &beginningOfDate, interval: nil, forDate: date)
-        calendar.rangeOfUnit(.Day, startDate: &beginningOfBaseDate, interval: nil, forDate: baseDate)
-        let numberOfCalendarDaysBetweenDates = calendar.components(NSCalendarUnit.Day, fromDate: beginningOfBaseDate!, toDate: beginningOfDate!, options: NSCalendarOptions()).day
+        calendar.rangeOfUnit(.Day, startDate: &beginningOfStartDate, interval: nil, forDate: startDate)
+        calendar.rangeOfUnit(.Day, startDate: &beginningOfEndDate, interval: nil, forDate: endDate)
+        return calendar.components(
+            .Day,
+            fromDate: beginningOfStartDate!, toDate: beginningOfEndDate!,
+            options: NSCalendarOptions()
+        ).day
+    }
+    
+    func stringForDate(date: NSDate, relativeToDate baseDate: NSDate) -> String {
+        let numberOfCalendarDaysBetweenDates = getNumberOfCalendarDaysBetweenDates(baseDate, date)
         
         switch numberOfCalendarDaysBetweenDates {
         case -Int.max ... -2:

--- a/MegaControllerTests/RelativeTimeDateFormatterTests.swift
+++ b/MegaControllerTests/RelativeTimeDateFormatterTests.swift
@@ -9,6 +9,50 @@
 @testable import MegaController
 import XCTest
 
+
+class GetNumberOfCalendarDaysBetweenDatesTests: XCTestCase {
+    let calendar = NSCalendar.currentCalendar()
+    let baseDate = NSDate(timeIntervalSinceReferenceDate: 0)
+    
+    var dateFormatter: RelativeTimeDateFormatter!
+    override func setUp() {
+        dateFormatter = RelativeTimeDateFormatter(calendar: calendar)
+    }
+    
+    func testRelativeToToday() {
+        let testDate = calendar.dateByAddingUnit(.Hour, value: 1, toDate: baseDate, options: NSCalendarOptions())!
+        XCTAssertEqual(
+            dateFormatter.getNumberOfCalendarDaysBetweenDates(baseDate, testDate),
+            0
+        )
+    }
+    
+    func testRelativeToTomorrow() {
+        let testDate = calendar.dateByAddingUnit(.Day, value: 1, toDate: baseDate, options: NSCalendarOptions())!
+        XCTAssertEqual(
+            dateFormatter.getNumberOfCalendarDaysBetweenDates(baseDate, testDate),
+            1
+        )
+    }
+    
+    func testRelativeToLaterDate() {
+        let testDate = calendar.dateByAddingUnit(.Day, value: 4, toDate: baseDate, options: NSCalendarOptions())!
+        XCTAssertEqual(
+            dateFormatter.getNumberOfCalendarDaysBetweenDates(baseDate, testDate),
+            4
+        )
+    }
+    
+    func testRelativeToEarlierDate() {
+        let testDate = calendar.dateByAddingUnit(.Day, value: -4, toDate: baseDate, options: NSCalendarOptions())!
+        XCTAssertEqual(
+            dateFormatter.getNumberOfCalendarDaysBetweenDates(baseDate, testDate),
+            -4
+        )
+    }
+}
+
+
 class RelativeTimeDateFormatterTests: XCTestCase {
     let calendar = NSCalendar.currentCalendar()
     let baseDate = NSDate(timeIntervalSinceReferenceDate: 0)


### PR DESCRIPTION
Just checked out the repository and think this could be a good place for newcomers to see single purpose functions.

I started with a small refactoring at `MegaController/RelativeTimeDateFormatter.swift`.

When I first saw `stringForDate(date, relativeToDate)`, followed it line by line I have to keep myself thinking "OK, let's remember these `beginningOfDate` and `beginningOfBaseDate`, they could be in some interesting part later.". Depend on our limited memory not seems like a good practice. Refactoring it out makes `stringForDate` much cleaner for what it needs to compute the final result. :sparkles: 
